### PR TITLE
Change the directory references to reflect the new name, update variables and all other 'hyperterm' references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# HyperTerm Sync Settings
+# Hyper Sync Settings
 
-> Sync HyperTerm settings with Github.
+> Sync Hyper settings with Github.
 
 ## Setup
 
 1.  Create a [new personal access token](https://github.com/settings/tokens/new)
     which has the `gist` scope. Save your token to `personalAccessToken` inside
-    `~/.hyperterm_plugins/.hyperterm-sync-settings.json`. Alternatively, set the
-    `HYPERTERM_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN` environmental variable using
+    `~/.hyper_plugins/.hyper-sync-settings.json`. Alternatively, set the
+    `HYPER_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN` environmental variable using
     this token.
 
 2.  Create a [new gist](https://gist.github.com/) and save it. Save your gist id
     (last part of the url after the username) to `gistId` inside
-    `~/.hyperterm_plugins/.hyperterm-sync-settings.json`. Alternatively, set the
-    `HYPERTERM_SYNC_SETTINGS_GIST_ID` environmental variable using this id.
+    `~/.hyper_plugins/.hyper-sync-settings.json`. Alternatively, set the
+    `HYPER_SYNC_SETTINGS_GIST_ID` environmental variable using this id.
 
-3.  Restart HyperTerm.
+3.  Restart Hyper.
 
 **Disclaimer:** Github Gists are by default **public**. If you don't want other
 people to easily find your gist (i.e. if you use certain packages, storing
@@ -34,13 +34,13 @@ Use the commands below in the menu:
 
 2.  `Plugins > Sync Settings > Backup Settings`
 
-    Copies your `~/.hyperterm.js` file to your local repository and pushes it to
+    Copies your `~/.hyper.js` file to your local repository and pushes it to
     Github.
 
 3.  `Plugins > Sync Settings > Restore Settings`
 
     Fast forwards local repo with all new commits from Github and copies the new
-    settings to your `~/.hyperterm.js` file.
+    settings to your `~/.hyper.js` file.
 
 4.  `Plugins > Sync Settings > Open >`
 
@@ -49,10 +49,10 @@ Use the commands below in the menu:
     *   `Repo`: Opens the local repo that is cloned from the Gist.
 
     *   `Configuration`: Opens the
-        `~/.hyperterm_plugins/.hyperterm-sync-settings.json` config file.
+        `~/.hyper_plugins/.hyper-sync-settings.json` config file.
 
 ## Configuration
-Add `syncSettings` in your `.hyperterm.js` config. The configuration below shows all existing configuration values in their default states.
+Add `syncSettings` in your `.hyper.js` config. The configuration below shows all existing configuration values in their default states.
 
 ```javascript
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -15,14 +15,14 @@ exports.onWindow = win => {
 
 let commands;
 let config;
-let hypertermConfig;
+let hyperConfig;
 const checkForMissingSettings = () => {
   config = getGitConfig();
   const { personalAccessToken, gistId } = config;
-  hypertermConfig = app.config.getConfig().syncSettings || defaultConfig;
+  hyperConfig = app.config.getConfig().syncSettings || defaultConfig;
 
   if (personalAccessToken && gistId) {
-    commands = getCommands(config, open.notification, hypertermConfig);
+    commands = getCommands(config, open.notification, hyperConfig);
     return true;
   } else {
     if (!personalAccessToken && !gistId) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,7 +1,7 @@
 const { homedir } = require('os');
 const { resolve: resolvePath } = require('path');
 
-const title = 'hyperterm-sync-settings';
+const title = 'hyper-sync-settings';
 exports.title = title;
 
 const errorTitle = `${title} error 🔥`;
@@ -12,12 +12,12 @@ exports.setupUrl = setupUrl;
 
 const paths = { dirs: {} };
 paths.dirs.home = homedir();
-paths.dirs.repo = resolvePath(paths.dirs.home, './.hyperterm_plugins/.hyperterm-sync-settings');
+paths.dirs.repo = resolvePath(paths.dirs.home, './.hyper_plugins/.hyper-sync-settings');
 paths.files = {
-  config: resolvePath(paths.dirs.home, './.hyperterm_plugins/.hyperterm-sync-settings.json'),
+  config: resolvePath(paths.dirs.home, './.hyper_plugins/.hyper-sync-settings.json'),
   configTemplate: resolvePath(__dirname, './config.default.json'),
-  backup: resolvePath(paths.dirs.repo, './.hyperterm.js'),
-  restore: resolvePath(paths.dirs.home, './.hyperterm.js'),
+  backup: resolvePath(paths.dirs.repo, './.hyper.js'),
+  restore: resolvePath(paths.dirs.home, './.hyper.js'),
 };
 exports.paths = paths;
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,7 +7,7 @@ exports.title = title;
 const errorTitle = `${title} error 🔥`;
 exports.errorTitle = errorTitle;
 
-const setupUrl = 'https://github.com/dfrankland/hyperterm-sync-settings#setup';
+const setupUrl = 'https://github.com/dfrankland/hyper-sync-settings#setup';
 exports.setupUrl = setupUrl;
 
 const paths = { dirs: {} };

--- a/lib/getCommands/backup.js
+++ b/lib/getCommands/backup.js
@@ -17,7 +17,7 @@ module.exports = config =>
             repo =>
               repo
                 .createCommitOnHead(
-                  ['.hyperterm.js'],
+                  ['.hyper.js'],
                   repo.defaultSignature(),
                   repo.defaultSignature(),
                   `${new Date()}`

--- a/lib/getCommands/index.js
+++ b/lib/getCommands/index.js
@@ -3,7 +3,7 @@ const updates = require('./updates');
 const restore = require('./restore');
 const backup = require('./backup');
 
-module.exports = (config, notify, hypertermConfig) => {
+module.exports = (config, notify, hyperConfig) => {
   const catchError = err => {
     console.trace(err);
     notify(errorTitle, err);
@@ -20,7 +20,7 @@ module.exports = (config, notify, hypertermConfig) => {
                 'Your settings need to be updated.',
                 config.url
               );
-            } else if (!hypertermConfig.quiet) {
+            } else if (!hyperConfig.quiet) {
               notify(
                 `${title} 👍`,
                 'Your settings are up to date.',

--- a/lib/getGitConfig.js
+++ b/lib/getGitConfig.js
@@ -5,19 +5,19 @@ const { paths, gistUrl } = require('./constants');
 let config = {};
 
 const {
-  HYPERTERM_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN,
-  HYPERTERM_SYNC_SETTINGS_GIST_ID,
+  HYPER_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN,
+  HYPER_SYNC_SETTINGS_GIST_ID,
 } = process.env;
 
 if (
-  !HYPERTERM_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN ||
-  !HYPERTERM_SYNC_SETTINGS_GIST_ID
+  !HYPER_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN ||
+  !HYPER_SYNC_SETTINGS_GIST_ID
 ) {
   try {
     config = require(paths.files.config);
   } catch (err) {
     console.error(
-      `hyperterm-sync-settings: error 🔥 no config file found in \`${
+      `hyper-sync-settings: error 🔥 no config file found in \`${
         paths.files.config
       }\`, creating one`
     );
@@ -25,12 +25,12 @@ if (
   }
 }
 
-if (HYPERTERM_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN) {
-  config.personalAccessToken = HYPERTERM_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN;
+if (HYPER_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN) {
+  config.personalAccessToken = HYPER_SYNC_SETTINGS_PERSONAL_ACCESS_TOKEN;
 }
 
-if (HYPERTERM_SYNC_SETTINGS_GIST_ID) {
-  config.gistId = HYPERTERM_SYNC_SETTINGS_GIST_ID;
+if (HYPER_SYNC_SETTINGS_GIST_ID) {
+  config.gistId = HYPER_SYNC_SETTINGS_GIST_ID;
 }
 
 module.exports = () => {
@@ -68,7 +68,7 @@ module.exports = () => {
                   .open(paths.dirs.repo)
                   .catch(
                     error =>
-                    console.trace('hyperterm-sync-settings: error 🔥 couldn\'t open repo', error)
+                    console.trace('hyper-sync-settings: error 🔥 couldn\'t open repo', error)
                   )
             )
       )

--- a/package.json
+++ b/package.json
@@ -1,17 +1,18 @@
 {
-  "name": "hyperterm-sync-settings",
+  "name": "hyper-sync-settings",
   "version": "1.5.1",
-  "description": "Sync HyperTerm settings with Github.",
+  "description": "Sync Hyper settings with Github.",
   "main": "index.js",
   "scripts": {
     "test": ""
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dfrankland/hyperterm-sync-settings.git"
+    "url": "git+https://github.com/dfrankland/hyper-sync-settings.git"
   },
   "keywords": [
     "hyperterm",
+    "hyper",
     "sync",
     "settings",
     "backup",
@@ -20,9 +21,9 @@
   "author": "Dylan Frankland <dylan@frankland.io>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dfrankland/hyperterm-sync-settings/issues"
+    "url": "https://github.com/dfrankland/hyper-sync-settings/issues"
   },
-  "homepage": "https://github.com/dfrankland/hyperterm-sync-settings#readme",
+  "homepage": "https://github.com/dfrankland/hyper-sync-settings#readme",
   "dependencies": {
     "bluebird": "^3.4.1",
     "fs-extra": "^0.30.0",


### PR DESCRIPTION
#15 I also included changing the references to this repository and NPMJS package info. I'm assuming you'll want to update the name of this repo and deprecate your old published package in favor of the new 'Hyper' name.
