### PR TITLE
Remove electron dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "bluebird": "^3.4.1",
-    "electron": "^1.4.15",
     "fs-extra": "^1.0.0",
     "moment": "^2.15.2",
     "rimraf": "^2.6.1",
@@ -50,7 +49,6 @@
         "env",
         {
           "targets": {
-            "electron": 1.4,
             "node": 6
           }
         }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
       [
         "env",
         {
-          "tagets": {
+          "targets": {
             "electron": 1.4,
             "node": 6
           }


### PR DESCRIPTION
Remove Electron dependency from `package.json` since it's not required for the plugin to work properly (see: https://github.com/zeit/hyper/issues/398#issuecomment-235131717).

Fixes #34.