### PR TITLE
Restore settings file while preserving attributes

### DIFF
--- a/src/lib/getCommands/restore.js
+++ b/src/lib/getCommands/restore.js
@@ -19,5 +19,7 @@ export default async ({ repoPromise }) => {
         .then(resolve)
     ),
   );
-  await fs.copyAsync(backupFile, restoreFile);
+  await fs.ensureFileAsync(restoreFile);
+  await fs.outputFileAsync(restoreFile,
+    await fs.readFileAsync(backupFile), { flag: 'r+' });
 };


### PR DESCRIPTION
The current `copyAsync` implementation does not preserve file system attributes on Windows. Hidden files, for instance, will become visible again using `copyAsync`. Unfortunately this function does not allow one to pass [file system flags](https://nodejs.org/api/fs.html#fs_file_system_flags) so I had to use a different method to copy the settings file.

The `r+` file system flag opens a file for reading/writing, throwing an exception if the file does not exist. We call `ensureFileSync` first to prevent that from happening. This is needed because the `w` file system flag (which would be enough and also preserve attributes) will fail with `EPERM` on Windows.