### PR TITLE
docs: Add installation instructions for new Hyper users

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 > Sync Hyper settings with Github.
 
+## Installation
+
+1. Open your Hyper settings (i.e., `.hyper.js`)
+
+2. Add `hyper-sync-settings` to `plugins` section
+
+```js
+// Example
+module.exports = {
+  ...,
+  plugins: [
+    'hyper-sync-settings'
+  ],
+  ...
+}
+```
+
+3. Save and restart Hyper!
+
 ## Setup
 
 1.  Create a [new personal access token][1] which has the `gist` scope. Save


### PR DESCRIPTION
As someone new to Hyper, I was scratching my head for a bit when I was trying to get this setup. By adding this section, this should help ease the barrier of entry for those who are newer to Hyper.