### PR TITLE
Add support for new config location

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ const home =
     ? join(process.env.XDG_CONFIG_HOME, 'hyper')
     : process.platform == 'win32' ? app.getPath('userData') : homedir();
 
-const repo = resolvePath(applicationDirectory, './.hyper_plugins/.hyper-sync-settings');
+const repo = resolvePath(home, './.hyper_plugins/.hyper-sync-settings');
 
 export const paths = {
   dirs: { home, repo },

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,4 @@
+import { app } from 'electron';
 import { homedir } from 'os';
 import { resolve as resolvePath } from 'path';
 
@@ -9,8 +10,15 @@ export const title = 'hyper-sync-settings';
 export const errorTitle = `${title} error 🔥`;
 export const setupUrl = 'https://github.com/dfrankland/hyper-sync-settings#setup';
 
-const home = homedir();
-const repo = resolvePath(home, './.hyper_plugins/.hyper-sync-settings');
+// If the user defines XDG_CONFIG_HOME they definitely want their config there,
+// otherwise use the home directory in linux/mac and userdata in windows
+const home =
+  process.env.XDG_CONFIG_HOME !== undefined
+    ? join(process.env.XDG_CONFIG_HOME, 'hyper')
+    : process.platform == 'win32' ? app.getPath('userData') : homedir();
+
+const repo = resolvePath(applicationDirectory, './.hyper_plugins/.hyper-sync-settings');
+
 export const paths = {
   dirs: { home, repo },
   files: {


### PR DESCRIPTION
Configuration location for Hyper v3.0.0 changed (more details here: https://github.com/zeit/hyper/pull/3584). This adds support for that using the exact same code from the aforementioned PR (kudos to @juancampa).