### PR TITLE
Change 'plugins' to 'Tools'

### DIFF
--- a/src/decorateMenu.ts
+++ b/src/decorateMenu.ts
@@ -76,7 +76,7 @@ export default (
 
   const newMenu = menu.map(
     (item: MenuItemConstructorOptions): MenuItemConstructorOptions => {
-      if (item.label !== 'Plugins') return item;
+      if (item.label !== 'Tools') return item;
       return {
         ...item,
         submenu: [


### PR DESCRIPTION
See more info https://github.com/vercel/hyper/issues/6270

Without this, no menu-items are showing if people using the newest version(s) of Hyper.